### PR TITLE
Fix silent error swallowing and stale mounted check

### DIFF
--- a/src/fork/firestore/helpers/useIsMounted.ts
+++ b/src/fork/firestore/helpers/useIsMounted.ts
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 
 export const useIsMounted = () => {
-  const [isMounted, setIsMounted] = useState(true);
+  const isMounted = useRef(true);
   useEffect(() => {
     return () => {
-      setIsMounted(false);
+      isMounted.current = false;
     };
   }, []);
   return isMounted;

--- a/src/fork/firestore/useCollection.ts
+++ b/src/fork/firestore/useCollection.ts
@@ -71,11 +71,11 @@ export function useCollectionOnce_fork<T = DocumentData>(
 
     try {
       const result = await get(query);
-      if (isMounted) {
+      if (isMounted.current) {
         setValue(result);
       }
     } catch (error) {
-      if (isMounted) {
+      if (isMounted.current) {
         setError(error as FirestoreError);
       }
     }

--- a/src/fork/firestore/useDocument.ts
+++ b/src/fork/firestore/useDocument.ts
@@ -72,11 +72,11 @@ export function useDocumentOnce_fork<T = DocumentData>(
 
       try {
         const result = await get(reference);
-        if (isMounted) {
+        if (isMounted.current) {
           setValue(result);
         }
       } catch (error) {
-        if (isMounted) {
+        if (isMounted.current) {
           setError(error as FirestoreError);
         }
       }

--- a/src/make-document.ts
+++ b/src/make-document.ts
@@ -2,8 +2,12 @@ import type { DocumentData, DocumentSnapshot } from "firebase/firestore";
 import type { FsDocument } from "~/types";
 
 export function makeDocument<T extends DocumentData>(doc: DocumentSnapshot<T>): FsDocument<T> {
+  const data = doc.data();
+  if (!data) {
+    throw new Error(`Document ${doc.ref.path} exists but has no data`);
+  }
   return {
     id: doc.id,
-    data: doc.data()!,
+    data,
   };
 }

--- a/src/make-mutable-document.ts
+++ b/src/make-mutable-document.ts
@@ -11,9 +11,13 @@ import type { FsMutableDocument, FsMutableDocumentInTransaction } from "~/types"
 export function makeMutableDocument<T extends DocumentData>(
   doc: DocumentSnapshot<T>,
 ): FsMutableDocument<T> {
+  const data = doc.data();
+  if (!data) {
+    throw new Error(`Document ${doc.ref.path} exists but has no data`);
+  }
   return {
     id: doc.id,
-    data: doc.data()!,
+    data,
     ref: doc.ref,
     update: (data: UpdateData<T>) => updateDoc(doc.ref, data),
     updateWithPartial: (data: Partial<T>) => updateDoc(doc.ref, data as UpdateData<T>),
@@ -25,9 +29,13 @@ export function makeMutableDocumentInTransaction<T extends DocumentData>(
   doc: DocumentSnapshot<T>,
   tx: Transaction,
 ): FsMutableDocumentInTransaction<T> {
+  const data = doc.data();
+  if (!data) {
+    throw new Error(`Document ${doc.ref.path} exists but has no data`);
+  }
   return {
     id: doc.id,
-    data: doc.data()!,
+    data,
     ref: doc.ref,
     update: (data: UpdateData<T>) => tx.update(doc.ref, data),
     updateWithPartial: (data: Partial<T>) => tx.update(doc.ref, data as UpdateData<T>),

--- a/src/use-document.ts
+++ b/src/use-document.ts
@@ -34,7 +34,11 @@ export function useDocumentMaybe<T extends DocumentData>(
   documentId?: string,
 ): [FsMutableDocument<T> | undefined, boolean] {
   const ref = documentId ? doc(collectionRef, documentId) : undefined;
-  const [snapshot, isLoading] = useDocument_fork(ref);
+  const [snapshot, isLoading, error] = useDocument_fork(ref);
+
+  if (error) {
+    throw error;
+  }
 
   const document = useMemo(
     () => (snapshot?.exists() ? makeMutableDocument(snapshot) : undefined),


### PR DESCRIPTION
Port of fixes from typed-firestore-react-native PR #17:

- `useDocumentMaybe` was discarding errors from the fork hook. Now throws on Firestore errors, consistent with the library's philosophy where Maybe variants tolerate missing documents but not errors.
- `makeDocument`, `makeMutableDocument`, and `makeMutableDocumentInTransaction` used `doc.data()!` non-null assertions. Replaced with runtime checks that throw a descriptive error if data is unexpectedly undefined.
- `useIsMounted` used `useState`, causing async callbacks in `useCallback` with empty deps to capture a stale closure value. Replaced with `useRef` so `.current` always reflects the actual mounted state.