### PR TITLE
Add standalone document mutation functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ typed abstractions that work with Firebase's web SDK (`firebase/firestore`).
 - `useCollection`, `useCollectionOnce` - Collection query hooks
 - `getDocument*`, `getSpecificDocument*` - Non-hook fetch functions for use with
   ReactQuery etc.
+- `setDocument`, `setSpecificDocument` - Create or overwrite documents
+- `updateDocument`, `updateSpecificDocument` - Partially update documents
+- `deleteDocument`, `deleteSpecificDocument` - Delete documents
 - `makeDocument`, `makeMutableDocument` - Factory functions
 
 **Error Handling**: Hooks throw errors instead of returning them (except

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ const { data, isError } = useQuery({
 | `getSpecificDocumentData`          | Fetch only the data part of a specific document                |
 | `getSpecificDocumentInTransaction` | Fetch a specific document as part of a transaction             |
 
+### Write Functions
+
+Standalone functions for creating, updating, and deleting documents without
+fetching them first. Useful when you already know the document path and just want
+to write.
+
+| Function                 | Description                                         |
+| ------------------------ | --------------------------------------------------- |
+| `setDocument`            | Create or overwrite a document (supports merge)     |
+| `setSpecificDocument`    | Create or overwrite a specific document              |
+| `updateDocument`         | Partially update an existing document                |
+| `updateSpecificDocument` | Partially update an existing specific document       |
+| `deleteDocument`         | Delete a document                                   |
+| `deleteSpecificDocument` | Delete a specific document                          |
+
+The `set*` functions accept an optional `SetOptions` parameter for `{ merge: true }` or `{ mergeFields: [...] }` behavior. The `*Specific*` variants accept a `DocumentReference` directly instead of a collection ref + id.
+
 ## Working with Documents
 
 The default immutable document type is `FsDocument<T>`. Use this type when you
@@ -167,7 +184,9 @@ for more info.
 
 ## Client-Side Mutations
 
-In my projects I prefer to have all mutations happen on the server-side via an
+This library provides both document-level mutation methods (on `FsMutableDocument`) and standalone [write functions](#write-functions) (`setDocument`, `updateDocument`, `deleteDocument`, etc.) for performing client-side writes.
+
+That said, in my projects I prefer to have all mutations happen on the server-side via an
 API call. You might want to consider that, especially if older versions of your
 app could be around for a while, like with mobile apps. A bug in client-side
 code could have lasting effects on the consistency of your database, and

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ Standalone functions for creating, updating, and deleting documents without
 fetching them first. Useful when you already know the document path and just want
 to write.
 
-| Function                 | Description                                         |
-| ------------------------ | --------------------------------------------------- |
-| `setDocument`            | Create or overwrite a document (supports merge)     |
-| `setSpecificDocument`    | Create or overwrite a specific document              |
-| `updateDocument`         | Partially update an existing document                |
-| `updateSpecificDocument` | Partially update an existing specific document       |
-| `deleteDocument`         | Delete a document                                   |
-| `deleteSpecificDocument` | Delete a specific document                          |
+| Function                 | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `setDocument`            | Create or overwrite a document (supports merge) |
+| `setSpecificDocument`    | Create or overwrite a specific document         |
+| `updateDocument`         | Partially update an existing document           |
+| `updateSpecificDocument` | Partially update an existing specific document  |
+| `deleteDocument`         | Delete a document                               |
+| `deleteSpecificDocument` | Delete a specific document                      |
 
 The `set*` functions accept an optional `SetOptions` parameter for `{ merge: true }` or `{ mergeFields: [...] }` behavior. The `*Specific*` variants accept a `DocumentReference` directly instead of a collection ref + id.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from "./make-mutable-document";
 export * from "./types";
 export * from "./use-collection";
 export * from "./use-document";
+export * from "./write-document";

--- a/src/write-document.ts
+++ b/src/write-document.ts
@@ -26,13 +26,13 @@ export function setDocument<T extends DocumentData>(
 export function setDocument<T extends DocumentData>(
   collectionRef: CollectionReference<T>,
   documentId: string,
-  data: WithFieldValue<T>,
+  data: WithFieldValue<T> | PartialWithFieldValue<T>,
   options?: SetOptions,
 ): Promise<void> {
   if (options) {
     return setDoc(doc(collectionRef, documentId), data as PartialWithFieldValue<T>, options);
   }
-  return setDoc(doc(collectionRef, documentId), data);
+  return setDoc(doc(collectionRef, documentId), data as WithFieldValue<T>);
 }
 
 export function setSpecificDocument<T extends DocumentData>(
@@ -46,13 +46,13 @@ export function setSpecificDocument<T extends DocumentData>(
 ): Promise<void>;
 export function setSpecificDocument<T extends DocumentData>(
   documentRef: DocumentReference<T>,
-  data: WithFieldValue<T>,
+  data: WithFieldValue<T> | PartialWithFieldValue<T>,
   options?: SetOptions,
 ): Promise<void> {
   if (options) {
     return setDoc(documentRef, data as PartialWithFieldValue<T>, options);
   }
-  return setDoc(documentRef, data);
+  return setDoc(documentRef, data as WithFieldValue<T>);
 }
 
 export function updateDocument<T extends DocumentData>(

--- a/src/write-document.ts
+++ b/src/write-document.ts
@@ -1,0 +1,57 @@
+import {
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  type CollectionReference,
+  type DocumentData,
+  type DocumentReference,
+  type SetOptions,
+  type UpdateData,
+  type WithFieldValue,
+} from "firebase/firestore";
+
+export function setDocument<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  documentId: string,
+  data: WithFieldValue<T>,
+  options?: SetOptions,
+): Promise<void> {
+  return setDoc(doc(collectionRef, documentId), data, options ?? {});
+}
+
+export function setSpecificDocument<T extends DocumentData>(
+  documentRef: DocumentReference<T>,
+  data: WithFieldValue<T>,
+  options?: SetOptions,
+): Promise<void> {
+  return setDoc(documentRef, data, options ?? {});
+}
+
+export function updateDocument<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  documentId: string,
+  data: UpdateData<T>,
+): Promise<void> {
+  return updateDoc(doc(collectionRef, documentId), data);
+}
+
+export function updateSpecificDocument<T extends DocumentData>(
+  documentRef: DocumentReference<T>,
+  data: UpdateData<T>,
+): Promise<void> {
+  return updateDoc(documentRef, data);
+}
+
+export function deleteDocument<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  documentId: string,
+): Promise<void> {
+  return deleteDoc(doc(collectionRef, documentId));
+}
+
+export function deleteSpecificDocument<T extends DocumentData>(
+  documentRef: DocumentReference<T>,
+): Promise<void> {
+  return deleteDoc(documentRef);
+}

--- a/src/write-document.ts
+++ b/src/write-document.ts
@@ -6,6 +6,7 @@ import {
   type CollectionReference,
   type DocumentData,
   type DocumentReference,
+  type PartialWithFieldValue,
   type SetOptions,
   type UpdateData,
   type WithFieldValue,
@@ -15,17 +16,43 @@ export function setDocument<T extends DocumentData>(
   collectionRef: CollectionReference<T>,
   documentId: string,
   data: WithFieldValue<T>,
+): Promise<void>;
+export function setDocument<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  documentId: string,
+  data: PartialWithFieldValue<T>,
+  options: SetOptions,
+): Promise<void>;
+export function setDocument<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  documentId: string,
+  data: WithFieldValue<T>,
   options?: SetOptions,
 ): Promise<void> {
-  return setDoc(doc(collectionRef, documentId), data, options ?? {});
+  if (options) {
+    return setDoc(doc(collectionRef, documentId), data as PartialWithFieldValue<T>, options);
+  }
+  return setDoc(doc(collectionRef, documentId), data);
 }
 
 export function setSpecificDocument<T extends DocumentData>(
   documentRef: DocumentReference<T>,
   data: WithFieldValue<T>,
+): Promise<void>;
+export function setSpecificDocument<T extends DocumentData>(
+  documentRef: DocumentReference<T>,
+  data: PartialWithFieldValue<T>,
+  options: SetOptions,
+): Promise<void>;
+export function setSpecificDocument<T extends DocumentData>(
+  documentRef: DocumentReference<T>,
+  data: WithFieldValue<T>,
   options?: SetOptions,
 ): Promise<void> {
-  return setDoc(documentRef, data, options ?? {});
+  if (options) {
+    return setDoc(documentRef, data as PartialWithFieldValue<T>, options);
+  }
+  return setDoc(documentRef, data);
 }
 
 export function updateDocument<T extends DocumentData>(


### PR DESCRIPTION
Adds standalone typed write functions (`setDocument`, `updateDocument`, `deleteDocument` and their `*SpecificDocument` variants) as thin wrappers around the Firestore SDK. These allow performing mutations without fetching the document first, which is useful when the caller already knows the document path.

The `set*` functions use overloads matching Firebase's own `setDoc` signature: without options all fields are required (`WithFieldValue<T>`), with `SetOptions` partial data is accepted (`PartialWithFieldValue<T>`).

Also updates the README and CLAUDE.md to document the new functions.