### PR TITLE
Add getDocuments and getDocumentsData functions

### DIFF
--- a/src/get-documents.ts
+++ b/src/get-documents.ts
@@ -12,9 +12,7 @@ export async function getDocuments<T extends DocumentData>(
   ...queryConstraints: QueryConstraint[]
 ) {
   const _query =
-    queryConstraints.length === 0
-      ? collectionRef
-      : query(collectionRef, ...queryConstraints);
+    queryConstraints.length === 0 ? collectionRef : query(collectionRef, ...queryConstraints);
 
   const snapshot = await getDocs(_query);
 
@@ -26,9 +24,7 @@ export async function getDocumentsData<T extends DocumentData>(
   ...queryConstraints: QueryConstraint[]
 ) {
   const _query =
-    queryConstraints.length === 0
-      ? collectionRef
-      : query(collectionRef, ...queryConstraints);
+    queryConstraints.length === 0 ? collectionRef : query(collectionRef, ...queryConstraints);
 
   const snapshot = await getDocs(_query);
 

--- a/src/get-documents.ts
+++ b/src/get-documents.ts
@@ -1,0 +1,36 @@
+import {
+  getDocs,
+  query,
+  type CollectionReference,
+  type DocumentData,
+  type QueryConstraint,
+} from "firebase/firestore";
+import { makeMutableDocument } from "./make-mutable-document";
+
+export async function getDocuments<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  ...queryConstraints: QueryConstraint[]
+) {
+  const _query =
+    queryConstraints.length === 0
+      ? collectionRef
+      : query(collectionRef, ...queryConstraints);
+
+  const snapshot = await getDocs(_query);
+
+  return snapshot.docs.map((doc) => makeMutableDocument(doc));
+}
+
+export async function getDocumentsData<T extends DocumentData>(
+  collectionRef: CollectionReference<T>,
+  ...queryConstraints: QueryConstraint[]
+) {
+  const _query =
+    queryConstraints.length === 0
+      ? collectionRef
+      : query(collectionRef, ...queryConstraints);
+
+  const snapshot = await getDocs(_query);
+
+  return snapshot.docs.map((doc) => doc.data());
+}

--- a/src/get-documents.ts
+++ b/src/get-documents.ts
@@ -1,5 +1,6 @@
 import {
   getDocs,
+  limit,
   query,
   type CollectionReference,
   type DocumentData,
@@ -12,7 +13,9 @@ export async function getDocuments<T extends DocumentData>(
   ...queryConstraints: QueryConstraint[]
 ) {
   const _query =
-    queryConstraints.length === 0 ? collectionRef : query(collectionRef, ...queryConstraints);
+    queryConstraints.length === 0
+      ? query(collectionRef, limit(500))
+      : query(collectionRef, ...queryConstraints);
 
   const snapshot = await getDocs(_query);
 
@@ -24,7 +27,9 @@ export async function getDocumentsData<T extends DocumentData>(
   ...queryConstraints: QueryConstraint[]
 ) {
   const _query =
-    queryConstraints.length === 0 ? collectionRef : query(collectionRef, ...queryConstraints);
+    queryConstraints.length === 0
+      ? query(collectionRef, limit(500))
+      : query(collectionRef, ...queryConstraints);
 
   const snapshot = await getDocs(_query);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./get-document";
+export * from "./get-documents";
 export * from "./get-specific-document";
 export * from "./make-document";
 export * from "./make-mutable-document";


### PR DESCRIPTION
Non-hook equivalents of `useCollection` for fetching collection documents once using `getDocs()`. Both functions accept a typed `CollectionReference` and optional query constraints.

- `getDocuments` returns `FsMutableDocument<T>[]`
- `getDocumentsData` returns `T[]`

Closes #1