### PR TITLE
Rename transaction methods to Tx suffix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ typed abstractions that work with Firebase's web SDK (`firebase/firestore`).
 - `FsDocument<T>` - Immutable document with `id` and `data`
 - `FsMutableDocument<T>` - Adds `ref`, `update`, `updateWithPartial`, and
   `delete` methods
-- `FsMutableDocumentInTransaction<T>` - Transaction variant
+- `FsMutableDocumentTx<T>` - Transaction variant
 
 **Main Exports**:
 

--- a/README.md
+++ b/README.md
@@ -113,16 +113,17 @@ const { data, isError } = useQuery({
 });
 ```
 
-| Function                           | Description                                                    |
-| ---------------------------------- | -------------------------------------------------------------- |
-| `getDocument`                      | Fetch a document                                               |
-| `getDocumentData`                  | Fetch only the data part of a document                         |
-| `getDocumentMaybe`                 | Fetch a document that might not exist                          |
-| `getDocumentInTransaction`         | Fetch a document as part of a transaction                      |
-| `getDocumentInTransactionMaybe`    | Fetch a document that might not exist as part of a transaction |
-| `getSpecificDocument`              | Fetch a specific document                                      |
-| `getSpecificDocumentData`          | Fetch only the data part of a specific document                |
-| `getSpecificDocumentInTransaction` | Fetch a specific document as part of a transaction             |
+| Function                  | Description                                                    |
+| ------------------------- | -------------------------------------------------------------- |
+| `getDocument`             | Fetch a document                                               |
+| `getDocumentData`         | Fetch only the data part of a document                         |
+| `getDocumentMaybe`        | Fetch a document that might not exist                          |
+| `getDocumentDataMaybe`    | Fetch only the data part of a document that might not exist    |
+| `getDocumentTx`           | Fetch a document as part of a transaction                      |
+| `getDocumentMaybeTx`      | Fetch a document that might not exist as part of a transaction |
+| `getSpecificDocument`     | Fetch a specific document                                      |
+| `getSpecificDocumentData` | Fetch only the data part of a specific document                |
+| `getSpecificDocumentTx`   | Fetch a specific document as part of a transaction             |
 
 ### Write Functions
 

--- a/src/get-document.ts
+++ b/src/get-document.ts
@@ -6,7 +6,7 @@ import {
   type Transaction,
 } from "firebase/firestore";
 import { invariant } from "~/utils";
-import { makeMutableDocument } from "./make-mutable-document";
+import { makeMutableDocument, makeMutableDocumentTx } from "./make-mutable-document";
 
 export async function getDocument<T extends DocumentData>(
   collectionRef: CollectionReference<T>,
@@ -52,7 +52,7 @@ export async function getDocumentDataMaybe<T extends DocumentData>(
   return snapshot.data();
 }
 
-export async function getDocumentInTransaction<T extends DocumentData>(
+export async function getDocumentTx<T extends DocumentData>(
   transaction: Transaction,
   collectionRef: CollectionReference<T>,
   documentId: string,
@@ -61,10 +61,10 @@ export async function getDocumentInTransaction<T extends DocumentData>(
 
   invariant(snapshot.exists(), `No document available at ${collectionRef.path}/${documentId}`);
 
-  return makeMutableDocument(snapshot);
+  return makeMutableDocumentTx(snapshot, transaction);
 }
 
-export async function getDocumentInTransactionMaybe<T extends DocumentData>(
+export async function getDocumentMaybeTx<T extends DocumentData>(
   transaction: Transaction,
   collectionRef: CollectionReference<T>,
   documentId: string,
@@ -75,5 +75,11 @@ export async function getDocumentInTransactionMaybe<T extends DocumentData>(
     return;
   }
 
-  return makeMutableDocument(snapshot);
+  return makeMutableDocumentTx(snapshot, transaction);
 }
+
+/** @deprecated Use `getDocumentTx` instead */
+export const getDocumentInTransaction = getDocumentTx;
+
+/** @deprecated Use `getDocumentMaybeTx` instead */
+export const getDocumentInTransactionMaybe = getDocumentMaybeTx;

--- a/src/get-specific-document.ts
+++ b/src/get-specific-document.ts
@@ -5,8 +5,7 @@ import {
   type Transaction,
 } from "firebase/firestore";
 import { invariant } from "~/utils";
-import { makeDocument } from "./make-document";
-import { makeMutableDocument } from "./make-mutable-document";
+import { makeMutableDocument, makeMutableDocumentTx } from "./make-mutable-document";
 
 export async function getSpecificDocument<T extends DocumentData>(
   documentRef: DocumentReference<T>,
@@ -28,7 +27,7 @@ export async function getSpecificDocumentData<T extends DocumentData>(
   return docSnap.data();
 }
 
-export async function getSpecificDocumentFromTransaction<T extends DocumentData>(
+export async function getSpecificDocumentTx<T extends DocumentData>(
   transaction: Transaction,
   documentRef: DocumentReference<T>,
 ) {
@@ -36,5 +35,8 @@ export async function getSpecificDocumentFromTransaction<T extends DocumentData>
 
   invariant(snapshot.exists(), `No document available at ${documentRef.path}`);
 
-  return makeDocument(snapshot);
+  return makeMutableDocumentTx(snapshot, transaction);
 }
+
+/** @deprecated Use `getSpecificDocumentTx` instead */
+export const getSpecificDocumentFromTransaction = getSpecificDocumentTx;

--- a/src/make-mutable-document.ts
+++ b/src/make-mutable-document.ts
@@ -6,7 +6,7 @@ import {
   type Transaction,
   type UpdateData,
 } from "firebase/firestore";
-import type { FsMutableDocument, FsMutableDocumentInTransaction } from "~/types";
+import type { FsMutableDocument, FsMutableDocumentTx } from "~/types";
 
 export function makeMutableDocument<T extends DocumentData>(
   doc: DocumentSnapshot<T>,
@@ -25,10 +25,10 @@ export function makeMutableDocument<T extends DocumentData>(
   };
 }
 
-export function makeMutableDocumentInTransaction<T extends DocumentData>(
+export function makeMutableDocumentTx<T extends DocumentData>(
   doc: DocumentSnapshot<T>,
   tx: Transaction,
-): FsMutableDocumentInTransaction<T> {
+): FsMutableDocumentTx<T> {
   const data = doc.data();
   if (!data) {
     throw new Error(`Document ${doc.ref.path} exists but has no data`);
@@ -42,3 +42,6 @@ export function makeMutableDocumentInTransaction<T extends DocumentData>(
     delete: () => tx.delete(doc.ref),
   };
 }
+
+/** @deprecated Use `makeMutableDocumentTx` instead */
+export const makeMutableDocumentInTransaction = makeMutableDocumentTx;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type FsMutableDocument<T> = Readonly<{
 }> &
   FsDocument<T>;
 
-export type FsMutableDocumentInTransaction<T> = Readonly<{
+export type FsMutableDocumentTx<T> = Readonly<{
   ref: DocumentReference;
   update: (data: UpdateData<T>) => Transaction;
   /**
@@ -34,3 +34,6 @@ export type FsMutableDocumentInTransaction<T> = Readonly<{
   delete: () => Transaction;
 }> &
   FsDocument<T>;
+
+/** @deprecated Use `FsMutableDocumentTx` instead */
+export type FsMutableDocumentInTransaction<T> = FsMutableDocumentTx<T>;


### PR DESCRIPTION
Rename `InTransaction`/`FromTransaction` naming to the `Tx` suffix convention used by `@typed-firestore/server`. The `Tx` suffix goes at the end, with `Maybe` before it (e.g. `getDocumentMaybeTx`).

Fixes two bugs:
- `getDocumentTx` and `getDocumentMaybeTx` were using `makeMutableDocument` instead of `makeMutableDocumentTx`, so mutations bypassed the transaction.
- `getSpecificDocumentTx` was returning an immutable `FsDocument` instead of a mutable `FsMutableDocumentTx`.

Deprecated re-exports are provided for all old names to maintain backward compatibility.